### PR TITLE
bug fix for "add_error()" undefined method

### DIFF
--- a/class-wc-gateway-payu.php
+++ b/class-wc-gateway-payu.php
@@ -521,7 +521,8 @@ function init_your_gateway_class() {
 				$order = new WC_Order($_GET['order_id']);								
 				
 				$transactionNotes = "Payment Cancelled";
-				$woocommerce->add_error(__('', 'woothemes') . $transactionNotes);				
+				//$woocommerce->add_error(__('', 'woothemes') . $transactionNotes);	
+				wc_add_notice(__('', 'woothemes') . $transactionNotes, 'error');			
 				$order->add_order_note( __( 'Payment cancelled:'. $transactionNotes, 'woocommerce' ) );								
 				if ( 'yes' == $this->debug ) {
 					$this->log->add( 'PayU', 'Payment cancelled.' );
@@ -666,9 +667,11 @@ function init_your_gateway_class() {
 								// Payment completed
 								$order->add_order_note( __( 'Payment completed: <br />'. $transactionNotes, 'woocommerce' ) );
 								$order->payment_complete();		
-								$woocommerce -> cart -> empty_cart();	
+								$woocommerce->cart->empty_cart();	
 								if ( 'yes' == $this->debug )
-									$this->log->add( 'PayU', 'Payment complete.' );																
+									$this->log->add( 'PayU', 'Payment complete.' );										
+
+								wc_add_notice( __( 'Payment completed: <br />'. $transactionNotes, 'woocommerce' ), 'success');						
 								wp_redirect( $this->get_return_url( $order ) );
 								exit;												                
 							}            
@@ -729,7 +732,8 @@ function init_your_gateway_class() {
 							
 							$reason = $getTransactionResponse['soapResponse']['displayMessage'];
 							$transactionNotes = "PayU Reference: ".$getTransactionResponse['soapResponse']['payUReference'].", Error: ".addslashes($errorMessage).", Point Of Failure: ".$getTransactionResponse['soapResponse']['pointOfFailure'].", Result Code:".$getTransactionResponse['soapResponse']['resultCode'] ;            						
-							$woocommerce->add_error(__('Payment Failed:', 'woothemes') . $reason);				
+							//$woocommerce->add_error(__('Payment Failed:', 'woothemes') . $reason);	
+							wc_add_notice(__('Payment Failed:', 'woothemes') . $reason, 'error');			
 							$order->add_order_note( __( 'Payment unsuccessful:'. $transactionNotes, 'woocommerce' ) );								
 							if ( 'yes' == $this->debug ) {
 								$this->log->add( 'PayU', 'Payment Failed.' );
@@ -752,7 +756,8 @@ function init_your_gateway_class() {
 						
 						$reason = $getTransactionResponse['soapResponse']['displayMessage'];
 						$transactionNotes = "PayU Reference: ".$getTransactionResponse['soapResponse']['payUReference'].", Error: ".addslashes($errorMessage).", Point Of Failure: ".$getTransactionResponse['soapResponse']['pointOfFailure'].", Result Code:".$getTransactionResponse['soapResponse']['resultCode'] ;            						
-						$woocommerce->add_error(__('Payment Failed:', 'woothemes') . $reason);				
+						//$woocommerce->add_error(__('Payment Failed:', 'woothemes') . $reason);	
+						wc_add_notice(__('Payment Failed:', 'woothemes') . $reason, 'error');			
 						$order->add_order_note( __( 'Payment unsuccessful:'. $transactionNotes, 'woocommerce' ) );								
 						if ( 'yes' == $this->debug ) {
 							$this->log->add( 'PayU', 'Payment Failed.' );


### PR DESCRIPTION
This fix is applicable when using the plugin for WooCommerce v 2.5+ / Wordpress v4.5+.